### PR TITLE
Zusätzlich Einstellmöglichkeit: Arbeitszeit während Absenz nicht von Absenz abziehen

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -624,7 +624,7 @@ if($_SESSION['admin']){
 	// ----------------------------------------------------------------------------
 	// Monatsdaten berechnen
 	// ----------------------------------------------------------------------------
-	$_monat         = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $_time->_jahr, $_time->_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung, $_settings->_array[21][1],$_settings->_array[22][1],$_settings->_array[27][1]);
+	$_monat         = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $_time->_jahr, $_time->_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung, $_settings->_array[21][1],$_settings->_array[22][1],$_settings->_array[27][1], $_settings->_array[28][1]);
 	$_monat->_modal = $_template->_modal;
 	// Falls automatische Pause eingestellt
 	// TODO : wurde anderst gelöst, entfernen

--- a/android.php
+++ b/android.php
@@ -71,7 +71,7 @@ if($login){
         $_user = new time_user();
         $_user->load_data_session();
         $_absenz = new time_absenz($_user->_ordnerpfad, $_time->_jahr);
-        $_monat         = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $_time->_jahr, $_time->_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung, $_settings->_array[21][1],$_settings->_array[22][1],$_settings->_array[27][1]);
+        $_monat         = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $_time->_jahr, $_time->_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung, $_settings->_array[21][1],$_settings->_array[22][1],$_settings->_array[27][1], $_settings->_array[28][1]);
         $_jahr = new time_jahr($_user->_ordnerpfad, 0, $_user->_BeginnDerZeitrechnung, $_user->_Stunden_uebertrag, $_user->_Ferienguthaben_uebertrag, $_user->_Ferien_pro_Jahr, $_user->_Vorholzeit_pro_Jahr, $_user->_modell, $_time->_timestamp);
         // ----------------------------------------------------------------------------------------------
         // Controller action - Handling

--- a/include/Settings/settings.txt
+++ b/include/Settings/settings.txt
@@ -26,3 +26,4 @@ Landeseinstellung (Bundes - Feiertag)#1#Landeseinstellung f&uuml;r den Bundes - 
 <img src='images/icons/cut.png' border='0'> Runden der Quicktime#0#Quicktime - Runden / Beispiel: runden auf 5 Min. = Stempelzeit 7.57 bis 8.02 wird auf 8 Uhr gerundet. (0=inaktiv)
 <img src='images/icons/group_key.png' border='0'> Admin Komplett#1#Admin kann alles editieren (Stempelzeit, Zeiten hinzuf&uuml;gen, Abwesenheit, Rapport) auch wenn deaktiviert
 <img src='images/icons/group_key.png' border='0'> Absenz Berechnung#1#nur bis zum heutigen Tag Absenzen berechnen
+<img src='images/icons/group_key.png' border='0'> Absenz Berechnung#1#Arbeitszeit wird von der Absenz abgezogen

--- a/include/class_month.php
+++ b/include/class_month.php
@@ -22,6 +22,7 @@ class time_month{
 	private $_setautopause			= "";
 	private $_zeitzuschlag			= NULL;
 	private $_absenzberechnung 		= NULL;	
+	private $_absenzberechnungArbeitszeit = NULL;
 	public $_SollProTag 			= NULL;	// Soll Arbeitszeit pro Tag
 	public $_letzterTag				= NULL;	// Anzahl der Tage im gewählen Monat	
 	public $_SummeSollProMonat 	= NULL;	// Summe der Soll - Stunden im Monat
@@ -40,7 +41,7 @@ class time_month{
 	public $_modal				= NULL;
 	public $_modal_str				= NULL;
 	
-	function __construct($SettingCountry, $lastday, $ordnerpfad, $jahr, $monat, $arbeitstage, $ufeiertag, $_SollProTag, $_startzeit, $arbeitszeit, $autopause, $absenzberechnung){	
+	function __construct($SettingCountry, $lastday, $ordnerpfad, $jahr, $monat, $arbeitstage, $ufeiertag, $_SollProTag, $_startzeit, $arbeitszeit, $autopause, $absenzberechnung, $absenzberechnungArbeitszeit){
 		$this->_file = "./Data/".$ordnerpfad."/Rapport/";
 		$this->_pfad = "./Data/".$ordnerpfad."/";
 		$this->_arbeitstage	= $arbeitstage;
@@ -57,6 +58,7 @@ class time_month{
 		$this->_arbeitszeit = $arbeitszeit;	
 		$this->_autopause	= $autopause;
 		$this->_absenzberechnung = $absenzberechnung;
+		$this->_absenzberechnungArbeitszeit = $absenzberechnungArbeitszeit;
 		//Absenzenberechnung nur bis Heute in den Settings?
 		if($absenzberechnung){ $this->absenzsetting(); }
 		//Monatsdaten berechnen und im Array speichern
@@ -205,11 +207,13 @@ class time_month{
 				$saldo = $this->_MonatsArray[$i][18] + $this->_MonatsArray[$i][13];
 			}
 			// wenn eine Absenz vorhanden ist und das saldo >0 sowie tmp=0(nicht in der Zukunft)
-			if($this->_MonatsArray[$i][15] == 1 and $saldo > 0 and $tmp1==0){
-				$this->_MonatsArray[$i][18] = round(($this->_MonatsArray[$i][8] - $this->_MonatsArray[$i][13])*$this->_MonatsArray[$i][17]/100, 2);
-				$this->_MonatsArray[$i][15] = round((($this->_MonatsArray[$i][8]-$this->_MonatsArray[$i][13])/$this->_MonatsArray[$i][8]),2);
-				$this->_MonatsArray[$i][15] = round($this->_MonatsArray[$i][15]*$this->_MonatsArray[$i][4],2);
-				$saldo = $this->_MonatsArray[$i][18] + $this->_MonatsArray[$i][13] - $this->_MonatsArray[$i][8];
+            if($this->_absenzberechnungArbeitszeit == 1){
+			    if($this->_MonatsArray[$i][15] == 1 and $saldo > 0 and $tmp1==0){
+                $this->_MonatsArray[$i][18] = round(($this->_MonatsArray[$i][8] - $this->_MonatsArray[$i][13])*$this->_MonatsArray[$i][17]/100, 2);
+                $this->_MonatsArray[$i][15] = round((($this->_MonatsArray[$i][8]-$this->_MonatsArray[$i][13])/$this->_MonatsArray[$i][8]),2);
+                $this->_MonatsArray[$i][15] = round($this->_MonatsArray[$i][15]*$this->_MonatsArray[$i][4],2);
+                $saldo = $this->_MonatsArray[$i][18] + $this->_MonatsArray[$i][13] - $this->_MonatsArray[$i][8];
+                }
 			}
 			$saldo = round($saldo,2);
 			$this->_MonatsArray[$i][20] = $saldo;

--- a/include/time_funktion_pdf.php
+++ b/include/time_funktion_pdf.php
@@ -28,12 +28,12 @@ function erstelle_neu($_drucktime)
 			$tmp_jahr  = $tmp_jahr - 1;
 		}
 		// Falls der Mitarbeiter Drucken darf ist das nur der letzte Monat
-		$_monat = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $tmp_jahr, $tmp_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung,$_settings->_array[21][1],$_settings->_array[22][1], $_settings->_array[27][1]);
+		$_monat = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $tmp_jahr, $tmp_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung,$_settings->_array[21][1],$_settings->_array[22][1], $_settings->_array[27][1], $_settings->_array[28][1]);
 		$_jahr  = new time_jahr($_user->_ordnerpfad, 0, $_user->_BeginnDerZeitrechnung, $_user->_Stunden_uebertrag, $_user->_Ferienguthaben_uebertrag, $_user->_Ferien_pro_Jahr, $_user->_Vorholzeit_pro_Jahr, $_user->_modell, $_drucktime);
 	}
 	else
 	{
-		$_monat = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $_time->_jahr, $_time->_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung,$_settings->_array[21][1],$_settings->_array[22][1], $_settings->_array[27][1]);
+		$_monat = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $_time->_jahr, $_time->_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung,$_settings->_array[21][1],$_settings->_array[22][1], $_settings->_array[27][1], $_settings->_array[28][1]);
 		$_jahr  = new time_jahr($_user->_ordnerpfad, 0, $_user->_BeginnDerZeitrechnung, $_user->_Stunden_uebertrag, $_user->_Ferienguthaben_uebertrag, $_user->_Ferien_pro_Jahr, $_user->_Vorholzeit_pro_Jahr, $_user->_modell,$_time->_timestamp);
 	}
 

--- a/index.php
+++ b/index.php
@@ -511,7 +511,7 @@ if($_SESSION['admin']){
 	// ----------------------------------------------------------------------------
 	// Monatsdaten berechnen
 	// ----------------------------------------------------------------------------
-	$_monat         = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $_time->_jahr, $_time->_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung, $_settings->_array[21][1],$_settings->_array[22][1],$_settings->_array[27][1]);
+	$_monat         = new time_month( $_settings->_array[12][1], $_time->_letzterTag, $_user->_ordnerpfad, $_time->_jahr, $_time->_monat, $_user->_arbeitstage, $_user->_feiertage, $_user->_SollZeitProTag, $_user->_BeginnDerZeitrechnung, $_settings->_array[21][1],$_settings->_array[22][1],$_settings->_array[27][1], $_settings->_array[28][1]);
 	$_monat->_modal = $_template->_modal;
 	// ----------------------------------------------------------------------------
 	// Jahresdaten berechnen

--- a/modules/sites_admin/settings/001.php
+++ b/modules/sites_admin/settings/001.php
@@ -157,6 +157,27 @@ if($_settings->_array[27][1]==0){ $check2=" checked ";}else{$check2="";}
 			</tr></table>
 		</td>';
 $_anzeige = $_anzeige .  "<td class=td_background_tag align=left><img title='".$_settings->_array[27][2]."' src='images/icons/information.png' border=0></td></tr>";
+
+//------------------------------------------------------------------------------------
+// Absenzen - Arbeitszeit wird von der Absenz abgezogen (Zeile 29)
+//------------------------------------------------------------------------------------
+$_anzeige = $_anzeige . "<tr><td colspan='3' class=td_background_top>Absenzen - Arbeitszeit wird von der Absenz abgezogen</td></tr>";
+$_anzeige = $_anzeige . "<tr width=50%>";
+$_anzeige = $_anzeige . "<td class=td_background_tag align=left align=left>". $_settings->_array[28][0] . "</td>";
+if($_settings->_array[28][1]==1){ $check1=" checked ";}else{$check1="";}
+if($_settings->_array[28][1]==0){ $check2=" checked ";}else{$check2="";}
+$_anzeige = $_anzeige . '
+		<td class=td_background_tag align=left>
+			<table border="0" cellspacing="0" cellpadding="0" ><tr>
+				<td><input type="radio" value="1" name="28" '. $check1 .'></td>
+				<td>ja (Standard)</td>
+				<td><input type="radio" value="0" name="28" '. $check2 .'></td>
+				<td>nein</td>
+			</tr></table>
+		</td>';
+$_anzeige = $_anzeige .  "<td class=td_background_tag align=left><img title='".$_settings->_array[28][2]."' src='images/icons/information.png' border=0></td></tr>";
+
+
 $y--;
 $_anzeige = $_anzeige . "	
 	<tr><td class=td_background_heute colspan='3' align=center >


### PR DESCRIPTION
Es wurde eine Einstellmöglichkeit hinzugefügt, damit anstelle der Verechnung von Arbeitszeit während der Absenz mit der Absenz, die Arbeitszeit als Plusstunden angerechnet werden.